### PR TITLE
Patch to fetch CheriBSD

### DIFF
--- a/etc/pot/flavours/fbsd-update.sh
+++ b/etc/pot/flavours/fbsd-update.sh
@@ -1,4 +1,11 @@
 #!/bin/sh
 
 export PAGER=/bin/cat
-freebsd-update --not-running-from-cron fetch install
+case $( . /etc/os-release; echo $NAME ) in
+    FreeBSD)
+        freebsd-update --not-running-from-cron fetch install
+    ;&
+    CheriBSD)
+        echo skipped freebsd-update for CheriBSD
+    ;;
+esac

--- a/share/pot/common.sh
+++ b/share/pot/common.sh
@@ -957,7 +957,7 @@ _fetch_freebsd_internal()
 	_archpath="$( echo "$2" | sed -e 's:-:/:' )"
 
 	if [ ! -r "${POT_CACHE}/${_rel}"_base.txz ]; then
-		fetch -m https://ftp.freebsd.org/pub/FreeBSD/releases/"$_archpath"/"${_rel}"/base.txz -o "${POT_CACHE}/${_rel}"_base.txz
+		fetch -m https://download.cheribsd.org/releases/"$_archpath/$(echo $_rel | cut -d '-' -f 1)"/ftp/base.txz -o "${POT_CACHE}/${_rel}"_base.txz
 	fi
 
 	if [ ! -r "${POT_CACHE}/${_rel}"_base.txz ]; then

--- a/share/pot/common.sh
+++ b/share/pot/common.sh
@@ -957,7 +957,15 @@ _fetch_freebsd_internal()
 	_archpath="$( echo "$2" | sed -e 's:-:/:' )"
 
 	if [ ! -r "${POT_CACHE}/${_rel}"_base.txz ]; then
-		fetch -m https://download.cheribsd.org/releases/"$_archpath/$(echo $_rel | cut -d '-' -f 1)"/ftp/base.txz -o "${POT_CACHE}/${_rel}"_base.txz
+		case $( . /etc/os-release; echo $NAME ) in
+		FreeBSD)
+			fetch -m https://ftp.freebsd.org/pub/FreeBSD/releases/"$_archpath"/"${_rel}"/base.txz -o "${POT_CACHE}/${_rel}"_base.txz
+		;&
+		CheriBSD)
+			_relpath="$(echo $_rel | cut -d '-' -f 1)/ftp"
+			fetch -m https://download.cheribsd.org/releases/"$_archpath"/"${_relpath}"/base.txz -o "${POT_CACHE}/${_rel}"_base.txz
+		;;
+		esac
 	fi
 
 	if [ ! -r "${POT_CACHE}/${_rel}"_base.txz ]; then


### PR DESCRIPTION
This patch should fix the fetch process used by Pot, to retrieve any CheriBSD base.txz file regardless of the architecture.

Since Pot requires valid releases to end in `-RELEASE`, the following script will create the appropriate directory structure and pull individual AArch64c manifests, for example, for CheriBSD from [download.cheribsd.org](https://download.cheribsd.org):

```shell
#!/bin/sh
mkdir -p /usr/local/share/freebsd/MANIFESTS/
	
releases=`curl -s https://download.cheribsd.org/releases/arm64/aarch64c/ | grep -Eo "\w{1,}\.\w{1,}" | sort -u`

for release in $releases;
	do curl "https://download.cheribsd.org/releases/arm64/aarch64c/$release/ftp/MANIFEST" > /usr/local/share/freebsd/MANIFESTS/arm64-aarch64c-$release-RELEASE;
	done
```